### PR TITLE
Reduce ambiguity in usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# git bayesect
+# `git bayesect`
 
 Bayesian git bisection!
 
@@ -11,16 +11,16 @@ has changed at some point in some direction
 ## Installation
 
 ```
-pip install git_bayesect
+pip install git-bayesect
 ```
 Or:
 ```
-uv tool install git_bayesect
+uv tool install git-bayesect
 ```
 
 ## How it works
 
-`git_bayesect` uses Bayesian inference to identify the commit introducing a change, with
+`git bayesect` uses Bayesian inference to identify the commit introducing a change, with
 commit selection performed via greedy minimisation of expected entropy, and using a Beta-Bernoulli
 conjugacy trick while calculating posterior probabilities to make handling unknown failure rates
 tractable.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "git_bayesect"
+name = "git-bayesect"
 version = "1.2"
 authors = [{name = "Shantanu Jain"}, {email = "hauntsaninja@gmail.com"}]
 description = "Git bisection with Bayesian statistics"
@@ -21,7 +21,6 @@ dependencies = [
 
 [project.scripts]
 git-bayesect = "git_bayesect:main"
-git_bayesect = "git_bayesect:main"
 
 [project.urls]
 homepage = "https://github.com/hauntsaninja/git_bayesect"


### PR DESCRIPTION
This removes the underscore variant since Git [only supports](https://github.com/git/git/blob/6a4418c36d6bad69a599044b3cf49dcbd049cb45/git.c#L935-L951) the `git-` prefix and PyPI normalizes the name of [this package](https://pypi.org/project/git-bayesect/) to `git-bayesect` due to [PEP 503](https://peps.python.org/pep-0503/#normalized-names).